### PR TITLE
Fix achievement names

### DIFF
--- a/index.html
+++ b/index.html
@@ -1872,7 +1872,7 @@
                                 <div id="I don't have enough fuel!" class="achievement achievementlocked" style="background-image: url(images/105.png)"><br></div>
                             </td>
                             <td>
-                                <div id="To sub-atomic!" class="achievement achievementlocked" style="background-image: url(images/106.png)" ach-tooltip="Go quantum. Reward: On your first eternity, you gain 20 eternitied stat instead of 1."><br></div>
+                                <div id="Sub-atomic" class="achievement achievementlocked" style="background-image: url(images/106.png)" ach-tooltip="Go quantum. Reward: On your first eternity, you gain 20 eternitied stat instead of 1."><br></div>
                             </td>
                             <td>
                                 <div id="Hadronization" class="achievement achievementlocked" style="background-image: url(images/107.png)" ach-tooltip="Have colored quarks but no color charge."><br></div>
@@ -1890,7 +1890,7 @@
                                 <div id="Old age" class="achievement achievementlocked" style="background-image: url(images/111.png)"><br></div>
                             </td>
                             <td>
-                                <div id="I already rid of you..." class="achievement achievementlocked" style="background-image: url(images/112.png)"><br></div>
+                                <div id="I already got rid of you..." class="achievement achievementlocked" style="background-image: url(images/112.png)"><br></div>
                             </td>
                         </tr>
                 </table>


### PR DESCRIPTION
Hi, this is Username5243 here. I've taken liberty to fix the grammar on some of the achievement names. BTW, you have descriptions missing for a few row 15 achievements - is that supposed to happen? Are you planning to add them later? (You can tell me on Discord if you want)

I'll be fixing more grammar as I reach the higher endgame (EC13/14, quantum etc.) but am trying to remain as spoiler-free of those parts as I can. So you don't get any fixes there now.