### PR TITLE
Fix tickboost autobuyer

### DIFF
--- a/javascripts/game.js
+++ b/javascripts/game.js
@@ -4143,6 +4143,7 @@ function updatePriorities() {
         player.autobuyers[13].priority = parseInt(document.getElementById("priority15").value)
         player.overXGalaxiesTickspeedBoost = parseInt(document.getElementById("overGalaxiesTickspeedBoost").value)
         player.autobuyers[13].bulk = Math.floor(Math.max(parseFloat(document.getElementById("bulkTickBoost").value), 1))
+        player.autobuyers[13].bulk = (isNaN(player.autobuyers[13].bulk)) ? 1 : player.autobuyers[13].bulk
     }
     player.autobuyers[10].bulk = parseFloat(document.getElementById("bulkgalaxy").value)
     const eterValue = fromValue(document.getElementById("priority13").value)
@@ -7828,11 +7829,7 @@ function autoBuyerTick() {
 
     if (player.tickspeedBoosts!=undefined) if (player.autobuyers[13]%1 !== 0) {
         if (autoTickspeedBoostBoolean()) {
-            let req=getTickspeedBoostRequirement()
-	    let amount=getAmount(req.tier)
-	    if (!(amount>=req.amount)) return
-            if (player.infinityUpgrades.includes("bulkBoost")) tickspeedBoost(Math.floor((amount-req.amount)/5+1))
-            tickspeedBoost(1)
+            tickspeedBoost(player.autobuyers[13].bulk)
             player.autobuyers[13].ticks = 0
         }
         player.autobuyers[13].ticks += 1;

--- a/javascripts/game.js
+++ b/javascripts/game.js
@@ -7828,7 +7828,11 @@ function autoBuyerTick() {
 
     if (player.tickspeedBoosts!=undefined) if (player.autobuyers[13]%1 !== 0) {
         if (autoTickspeedBoostBoolean()) {
-            tickspeedBoost(player.autobuyers[13].bulk)
+            let req=getTickspeedBoostRequirement()
+	    let amount=getAmount(req.tier)
+	    if (!(amount>=req.amount)) return
+            if (player.infinityUpgrades.includes("bulkBoost")) tickspeedBoost(Math.floor((amount-req.amount)/5+1))
+            tickspeedBoost(1)
             player.autobuyers[13].ticks = 0
         }
         player.autobuyers[13].ticks += 1;


### PR DESCRIPTION
Fixes tickboost autobuyer. Currently, the tickboost autobuyer sets tickboosts to NaN if its bulk buy hasn't been set yet, effectively making tickspeed useless. This fixes it by having it bulk buy 1 if the bulk buy resolves to NaN.