### PR TITLE
Moved Quantum Speedrun Achievements to updateSpeedrun function

### DIFF
--- a/javascripts/mods/ngpp.js
+++ b/javascripts/mods/ngpp.js
@@ -731,19 +731,6 @@ function quantumReset(force, auto, challid, bigRip, implode=false) {
 		if (tmp.qu.best>tmp.qu.time) {
 			tmp.qu.best=tmp.qu.time
 			updateSpeedruns()
-			if (speedrunMilestonesReached>23) giveAchievement("And the winner is...")
-			if (speedrunMilestonesReached>25) document.getElementById('rebuyupgmax').style.display="none"
-			if (speedrunMilestonesReached>27) {
-				giveAchievement("Special Relativity")
-				var removeMaxAll=false
-				for (d=1;d<9;d++) {
-					if (player.autoEterOptions["md"+d]) {
-						if (d>7) removeMaxAll=true
-					} else break
-				}
-				document.getElementById("metaMaxAllDiv").style.display=removeMaxAll?"none":""
-			}
-			if (tmp.qu.best<=10) giveAchievement("Quantum doesn't take so long")
 		}
 		tmp.qu.times++
 		if (!inQC(6)) {

--- a/javascripts/mods/ngppp.js
+++ b/javascripts/mods/ngppp.js
@@ -999,6 +999,19 @@ function updateSpeedruns() {
 		document.getElementById('sacrificeAuto').style.display=speedrunMilestonesReached>24?"":"none"
 		for (i=1;i<29;i++) document.getElementById("speedrunMilestone"+i).className="achievement achievement"+(speedrunMilestonesReached>=i?"un":"")+"locked"
 		for (i=1;i<5;i++) document.getElementById("speedrunRow"+i).className=speedrunMilestonesReached<(i>3?28:i*8)?"":"completedrow"
+		if (speedrunMilestonesReached>23) giveAchievement("And the winner is...")
+		if (speedrunMilestonesReached>25) document.getElementById('rebuyupgmax').style.display="none"
+		if (speedrunMilestonesReached>27) {
+			giveAchievement("Special Relativity")
+			var removeMaxAll=false
+			for (d=1;d<9;d++) {
+				if (player.autoEterOptions["md"+d]) {
+					if (d>7) removeMaxAll=true
+				} else break
+			}
+			document.getElementById("metaMaxAllDiv").style.display=removeMaxAll?"none":""
+		}
+		if (tmp.qu.best<=10) giveAchievement("Quantum doesn't take so long")
 	}
 }
 


### PR DESCRIPTION
As is, the game never checks for achievements if you never get a better quantum time than your best. Since updateSpeedruns is located in Load_Functions.js, this ensures a refresh will give you those achievements if you already have the required quantum time for it.