### PR TITLE
Correct a mismatch between 'Bulked up' achievement text & code

### DIFF
--- a/javascripts/game.js
+++ b/javascripts/game.js
@@ -41,7 +41,7 @@ function setupAutobuyerHTMLandData(){
 			player.autobuyers[id].cost = Math.ceil(2.4*player.autobuyers[id].cost);
 			var b1 = true;
 			for (let i=0;i<8;i++) {
-				if (player.autobuyers[i].bulk < 512) b1 = false;
+				if (player.autobuyers[i].bulk < 256) b1 = false;
 			}
 			if (b1) giveAchievement("Bulked up");
 		} else {


### PR DESCRIPTION
Old bug: player.autobuyers[].bulk stores values as 1/2 of their displayed & used value, so while the description for 'Bulked up' says "at least 512x" it's actually testing for 1024x. Alternate solution is to fix the achievement description to state 1024. (See also [the line where it's doubled](https://github.com/GhostCrab/IvarK.github.io/blob/master/javascripts/game.js#L3097).)