### PR TITLE
make sure to reset infinitied on eternity

### DIFF
--- a/javascripts/core/prestige_resets.js
+++ b/javascripts/core/prestige_resets.js
@@ -348,6 +348,7 @@ function checkSecondSetOnCrunchAchievements(){
 
 function doEternityResetStuff(layer = 4) {
 	player.infinityPoints = new Decimal(hasAch("r104") ? 2e25 : 0)
+	player.infinitied = 0
 	player.infMult = new Decimal(1)
 	player.infMultCost = new Decimal(10)
 	playerInfinityUpgradesOnEternity()


### PR DESCRIPTION
I believe this might have been missed back in Alpha 5.02 - https://github.com/aarextiaokhiao/IvarK.github.io/commit/68961f073791e56354ae7d92230dc432ec9868cd#diff-219db8d695a811ddf27a99ace2659e2878f1b2353e8034e320c9e98fef19af96L374

Without resetting infinitied, EC4 becomes basically impossible, as your infinitied count is always too large to successfully complete it